### PR TITLE
Harmony: Fat arrow and destructuring in params

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3222,6 +3222,11 @@ parseYieldExpression: true
                 state.parenthesizedCount === (oldParenthesizedCount + 1))) {
             if (expr.type === Syntax.Identifier) {
                 params = reinterpretAsCoverFormalsList([ expr ]);
+            // ADDED by Termi
+            // case example: ```(a = 1) => (  a + 1  , a  )``` throw wrong error: Line 1: Unexpected token =>
+            } else if (expr.type === Syntax.ObjectExpression || expr.type === Syntax.ArrayExpression || expr.type === Syntax.AssignmentExpression) {
+                params = reinterpretAsCoverFormalsList([expr]);
+            // ADDED by Termi
             } else if (expr.type === Syntax.SequenceExpression) {
                 params = reinterpretAsCoverFormalsList(expr.expressions);
             }

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -2098,7 +2098,95 @@ var harmonyTestFixture = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 17 }
             }
+        },
+
+        'fn(({field_name: field_value}) => field_name)' : {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'fn',
+                    range: [0, 2],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 2 }
+                    }
+                },
+                'arguments': [{
+                    type: 'ArrowFunctionExpression',
+                    id: null,
+                    params: [{
+                        type: 'ObjectPattern',
+                        properties: [{
+                            type: 'Property',
+                            key: {
+                                type: 'Identifier',
+                                name: 'field_name',
+                                range: [5, 15],
+                                loc: {
+                                    start: { line: 1, column: 5 },
+                                    end: { line: 1, column: 15 }
+                                }
+                            },
+                            value: {
+                                type: 'Identifier',
+                                name: 'field_value',
+                                range: [17, 28],
+                                loc: {
+                                    start: { line: 1, column: 17 },
+                                    end: { line: 1, column: 28 }
+                                }
+                            },
+                            kind: 'init',
+                            method: false,
+                            shorthand: false,
+                            computed: false,
+                            range: [5, 28],
+                            loc: {
+                                start: { line: 1, column: 5 },
+                                end: { line: 1, column: 28 }
+                            }
+                        }],
+                        range: [4, 29],
+                        loc: {
+                            start: { line: 1, column: 4 },
+                            end: { line: 1, column: 29 }
+                        }
+                    }],
+                    defaults: [],
+                    body: {
+                        type: 'Identifier',
+                        name: 'field_name',
+                        range: [34, 44],
+                        loc: {
+                            start: { line: 1, column: 34 },
+                            end: { line: 1, column: 44 }
+                        }
+                    },
+                    rest: null,
+                    generator: false,
+                    expression: true,
+                    range: [3, 44],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 44 }
+                    }
+                }],
+                range: [0, 45],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 45 }
+                }
+            },
+            range: [0, 45],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 45 }
+            }
+
         }
+
 
     },
 


### PR DESCRIPTION
Currently esprima throws an exception in cases where the arguments to a fat arrow function have destructuring:

```javascript
fn( ({ field_name: field_value}) => field_value); //'Unexpected token =>',
```

This PR will likely fix [issue 554][0] as well.

Note: this patch is from a downstream project that I saw doesn't have this problem: https://github.com/termi/es6-transpiler/blob/master/lib/esprima_harmony.js#L3390-L3394

[0]: https://code.google.com/p/esprima/issues/detail?id=554