### PR TITLE
Fix division by "this"

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1344,7 +1344,7 @@ parseStatement: true, parseSourceElement: true */
             }
             return collectRegex();
         }
-        if (prevToken.type === 'Keyword') {
+        if (prevToken.type === 'Keyword' && prevToken.value !== 'this') {
             return collectRegex();
         }
         return scanPunctuator();

--- a/test/test.js
+++ b/test/test.js
@@ -24018,8 +24018,82 @@ var testFixture = {
             lineNumber: 1,
             column: 8,
             message: 'Error: Line 1: Invalid regular expression: missing /'
-        }
+        },
 
+        'this / 100;': [
+          {
+            "type": "Keyword",
+            "value": "this",
+            "range": [
+              0,
+              4
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          },
+          {
+            "type": "Punctuator",
+            "value": "/",
+            "range": [
+              5,
+              6
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 5
+              },
+              "end": {
+                "line": 1,
+                "column": 6
+              }
+            }
+          },
+          {
+            "type": "Numeric",
+            "value": "100",
+            "range": [
+              7,
+              10
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            }
+          },
+          {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+              10,
+              11
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            }
+          }
+        ]
     },
 
     'API': {


### PR DESCRIPTION
`this / 100` is legal Javascript, and a variation of it actually appears
in moment.js.

Without this fix, esprima treats it as an un-terminated regular
expression.

https://code.google.com/p/esprima/issues/detail?id=616