### PR TITLE
[Harmony] Fix token errors/duplicates with Regexp

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1274,7 +1274,7 @@ parseYieldExpression: true
     }
 
     function scanRegExp() {
-        var str, ch, start, pattern, flags, value, classMarker = false, restore, terminated = false, tmp;
+        var str, ch, start, pattern, flags, value, classMarker = false, restore, terminated = false, tmp, token;
 
         lookahead = null;
         skipComment();
@@ -1387,10 +1387,8 @@ parseYieldExpression: true
             value = null;
         }
 
-        lookahead2();
-
         if (extra.tokenize) {
-            return {
+            token = {
                 type: Token.RegularExpression,
                 value: value,
                 regex: {
@@ -1401,16 +1399,21 @@ parseYieldExpression: true
                 lineStart: lineStart,
                 range: [start, index]
             };
+        } else {
+            lookahead2();
+
+            token = {
+                literal: str,
+                value: value,
+                regex: {
+                    pattern: pattern,
+                    flags: flags
+                },
+                range: [start, index]
+            };
         }
-        return {
-            literal: str,
-            value: value,
-            regex: {
-                pattern: pattern,
-                flags: flags
-            },
-            range: [start, index]
-        };
+
+        return token;
     }
 
     function isIdentifierName(token) {
@@ -5139,6 +5142,8 @@ parseYieldExpression: true
                 range: [pos, index],
                 loc: loc
             });
+
+            peek();
         }
 
         return regex;

--- a/esprima.js
+++ b/esprima.js
@@ -32,7 +32,7 @@
 
 /*jslint bitwise:true plusplus:true */
 /*global esprima:true, define:true, exports:true, window: true,
-throwError: true, generateStatement: true, peek: true,
+throwError: true, generateStatement: true, peek: true, lookahead2: true,
 parseAssignmentExpression: true, parseBlock: true,
 parseClassExpression: true, parseClassDeclaration: true, parseExpression: true,
 parseForStatement: true,
@@ -1387,7 +1387,7 @@ parseYieldExpression: true
             value = null;
         }
 
-        peek();
+        lookahead2();
 
         if (extra.tokenize) {
             return {

--- a/test/test.js
+++ b/test/test.js
@@ -18720,24 +18720,6 @@ var testFixture = {
                 }
             },
             {
-                "type": "Punctuator",
-                "value": ")",
-                "range": [
-                    13,
-                    14
-                ],
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 13
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 14
-                    }
-                }
-            },
-            {
                 "type": "RegularExpression",
                 "value": "/42/",
                 "regex": {
@@ -18867,24 +18849,6 @@ var testFixture = {
                     "end": {
                         "line": 1,
                         "column": 12
-                    }
-                }
-            },
-            {
-                "type": "Punctuator",
-                "value": "}",
-                "range": [
-                    18,
-                    19
-                ],
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 18
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 19
                     }
                 }
             },


### PR DESCRIPTION
This should fix the issue that regular expressions are messing around with tokens
see https://code.google.com/p/esprima/issues/detail?id=440
jscs-dev/node-jscs#685

I'm not sure what I did exactly, but as far as I understand peek() is also adding a token for the next token and lookahead2() is only gathering linenumbers etc. if in "tokenmode"

I'm not aware about any side effects. The tests ran through, I only had to change two tests, as they were expecting the wrong order.

This is the example I tested with:

var abc = /([A-Z])/g;

Before:

```json
[
    {
        "type": "Keyword",
        "value": "var"
    },
    {
        "type": "Identifier",
        "value": "abc"
    },
    {
        "type": "Punctuator",
        "value": "="
    },
    {
        "type": "Punctuator",
        "value": ";"
    },
    {
        "type": "RegularExpression",
        "value": "/([A-Z])/g",
        "regex": {
            "pattern": "([A-Z])",
            "flags": "g"
        }
    },
    {
        "type": "Punctuator",
        "value": ";"
    }
]
```

After:

```json
[
    {
        "type": "Keyword",
        "value": "var"
    },
    {
        "type": "Identifier",
        "value": "abc"
    },
    {
        "type": "Punctuator",
        "value": "="
    },
    {
        "type": "RegularExpression",
        "value": "/([A-Z])/g",
        "regex": {
            "pattern": "([A-Z])",
            "flags": "g"
        }
    },
    {
        "type": "Punctuator",
        "value": ";"
    }
]
```