### PR TITLE
Changed npmignore to add the whole test directory and remove innecessary directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,7 @@
-.git
 .travis.yml
-/node_modules/
-/assets/
-/coverage/
-/demo/
-/test/3rdparty
-/tools/
+node_modules
+assets
+coverage
+demo
+test
+tools


### PR DESCRIPTION
The test directory isn't needed at all when installed this package as a dependency and are 8MB we could save from network and disk. Also the .git directory is ignored by default, so there's no need to add it.
